### PR TITLE
Implement Get Current User Profile Endpoint

### DIFF
--- a/src/routes/user-routes.ts
+++ b/src/routes/user-routes.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { registerUser, loginUser } from '../services/user-services';
+import { registerUser, loginUser, getCurrentUser } from '../services/user-services';
 
 export const userRoutes = new Elysia({ prefix: '/api' })
   .post('/users', async ({ body, set }) => {
@@ -36,4 +36,25 @@ export const userRoutes = new Elysia({ prefix: '/api' })
       email: t.String(),
       password: t.String()
     })
+  })
+  .get('/users/current', async ({ headers, set }) => {
+    const auth = headers['authorization'];
+    if (!auth || !auth.startsWith('Bearer ')) {
+      set.status = 401;
+      return { data: 'unauthorized' };
+    }
+
+    const token = auth.split(' ')[1];
+
+    try {
+      const user = await getCurrentUser(token);
+      return { data: user };
+    } catch (error: any) {
+      if (error.message === 'unauthorized') {
+        set.status = 401;
+        return { data: 'unauthorized' };
+      }
+      set.status = 500;
+      return { data: 'Internal Server Error' };
+    }
   });

--- a/src/services/user-services.ts
+++ b/src/services/user-services.ts
@@ -72,3 +72,23 @@ export const loginUser = async (params: LoginUserParams) => {
 
   return token;
 };
+export const getCurrentUser = async (token: string) => {
+  // 1. Join sessions and users to find the user by token
+  const result = await db
+    .select({
+      id: users.id,
+      nama: users.username,
+      email: users.email,
+      created_at: users.createdAt,
+    })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.token, token))
+    .get();
+
+  if (!result) {
+    throw new Error('unauthorized');
+  }
+
+  return result;
+};


### PR DESCRIPTION
This PR adds the profiling endpoint GET /api/users/current. It securely retrieves user data by joining sessions and users tables based on the Bearer Token provided in the Authorization header.